### PR TITLE
Feature/allowing deep namespaces

### DIFF
--- a/Module.php
+++ b/Module.php
@@ -23,7 +23,7 @@ class Module implements AutoloaderProviderInterface
             'Zend\Loader\StandardAutoloader' => array(
                 'namespaces' => array(
 		    // if we're in a namespace deeper than one level we need to fix the \ in the path
-                    __NAMESPACE__ => __DIR__ . '/src/' . str_replace('\\', DIRECTORY_SEPARATOR, __NAMESPACE__),
+                    __NAMESPACE__ => __DIR__ . '/src/' . str_replace('\\', '/' , __NAMESPACE__),
                 ),
             ),
         );


### PR DESCRIPTION
If the module class is defined inside of a namespace deeper than one level, the path for the autoloader config will be incorrect as it'll blindly use the backslash as part of the path. e.g. /path/to/your/namepace\productname.

so a simple str_replace to replace the backslashes will fix this.

this change won't have any effect on existing single level namespaces, and will allow greater flexibility to how devs use the skeleton module with deep namespaces.
