### PR TITLE
Default to getting ZF2 via composer, not as a git submodule

### DIFF
--- a/tests/TestConfiguration.php.dist
+++ b/tests/TestConfiguration.php.dist
@@ -20,7 +20,7 @@
  * Never commit plaintext passwords to the source code repository.
  */
 
-define('ZF2_PATH', realpath(__DIR__ . '/../../../vendor/ZF2/library'));
+define('ZF2_PATH', realpath(__DIR__ . '/../../../vendor/zendframework/zendframework/library/'));
 
 /**
  * The bootstrap supports several more options, however most modules will


### PR DESCRIPTION
To use the ZendSkeletonModule with the ZendSkeletonApplication and getting Zend Framework via Composer (not as a submodule) I had to make this change. 
